### PR TITLE
Update pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /src
 
 COPY . /src
 
+RUN pip install --upgrade pip
+
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 CMD ["python", "-u", "train.py"]


### PR DESCRIPTION
docker-compose up failed because of old pip version.

```
Collecting grpcio>=1.8.6 (from tensorflow==1.10.1->-r requirements.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/cf/7a/9744998129fce7e29c5f2d8b0f545913b7383e65d8366fc0ae98d11936af/grpcio-1.28.1.tar.gz (19.5MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-obnl3web/grpcio/setup.py", line 191, in <module>
        if check_linker_need_libatomic():
      File "/tmp/pip-install-obnl3web/grpcio/setup.py", line 152, in check_linker_need_libatomic
        stderr=PIPE)
      File "/usr/local/lib/python3.6/subprocess.py", line 709, in __init__
        restore_signals, start_new_session)
      File "/usr/local/lib/python3.6/subprocess.py", line 1344, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'cc': 'cc'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-obnl3web/grpcio/
You are using pip version 18.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
ERROR: Service 'training' failed to build: The command '/bin/sh -c pip install --trusted-host pypi.python.org -r requirements.txt' returned a non-zero code: 1
```